### PR TITLE
fix:移除旧格式，修复get_msg panic

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -138,7 +138,7 @@ func LoginInteract() {
 	} else {
 		log.Info("将使用 device.json 内的设备信息运行Bot.")
 		var err error
-		if device, err = auth.LoadOrSaveDevice("device"); err != nil {
+		if device, err = auth.LoadOrSaveDevice("device.json"); err != nil {
 			log.Fatalf("加载设备信息失败: %v", err)
 		}
 	}

--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -345,7 +345,7 @@ func ToMessageContent(e []message.IMessageElement, source message.Source) (r []g
 				"data": global.MSG{"file": o.Name, "url": o.Url},
 			}
 		case *message.ImageElement:
-			data := global.MSG{"file": hex.EncodeToString(o.Md5) + ".image", "url": o.Url, "subType": uint32(o.SubType)}
+			data := global.MSG{"url": o.Url, "subType": uint32(o.SubType)}
 			switch {
 			case o.Flash:
 				data["type"] = "flash"


### PR DESCRIPTION
![9042c31651107f2d9dac36867995854d](https://github.com/user-attachments/assets/b047ecea-7aec-4609-b81b-819be2b849e7)
![a58151eceb8c09448b8673f0f0a343ac](https://github.com/user-attachments/assets/cb8038d4-4269-42f5-b70f-35c4e1f1b575)
存储图片消息的时候将空的md5也存了，导致后续reply消息获取原本消息时走了错误的分支，造成了panic。我看代码注释md5是旧协议才有，就先删了。