### PR TITLE
fix:at处理不完善

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -138,7 +138,7 @@ func LoginInteract() {
 	} else {
 		log.Info("将使用 device.json 内的设备信息运行Bot.")
 		var err error
-		if device, err = auth.LoadOrSaveDevice("device"); err != nil {
+		if device, err = auth.LoadOrSaveDevice("device.json"); err != nil {
 			log.Fatalf("加载设备信息失败: %v", err)
 		}
 	}

--- a/coolq/bot.go
+++ b/coolq/bot.go
@@ -283,9 +283,23 @@ func (bot *CQBot) SendGroupMessage(groupID int64, m *message.SendingMessage) (in
 		//	}
 		//	return bot.InsertGroupMessage(ret, source), nil
 		case *message.AtElement:
-			self := bot.Client.GetCachedMemberInfo(bot.Client.Uin, uint32(groupID))
-			if i.TargetUin == 0 && self.Permission == entity.Member {
-				e = message.NewText("@全体成员")
+			if i.TargetUin == 0 {
+				self := bot.Client.GetCachedMemberInfo(bot.Client.Uin, uint32(groupID))
+				if self.Permission != entity.Member {
+					e = message.NewText("@全体成员")
+				} else {
+					continue
+				}
+			} else {
+				member := bot.Client.GetCachedMemberInfo(i.TargetUin, uint32(groupID))
+				if member != nil {
+					i.TargetUid = member.Uid
+					if member.MemberCard != "" {
+						i.Display = "@" + member.MemberCard
+					} else {
+						i.Display = "@" + member.MemberName
+					}
+				}
 			}
 		}
 		newElem = append(newElem, e)


### PR DESCRIPTION
go-cq这边at消息未处理，largo那里选择无预处理，导致无法发送at消息。我在go-cq这边完善了对at的处理，同时修改了下@全体的逻辑，当不是管理员或者群主，忽略@全体消息。