### PR TITLE
fix: 优化获取群成员数据

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.7
 
 require (
 	github.com/FloatTech/sqlite v1.6.3
-	github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251025062608-50907f2e480b
+	github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251030033604-587d2268813f
 	github.com/Microsoft/go-winio v0.6.2-0.20230724192519-b29bbd58a65a
 	github.com/RomiChan/syncx v0.0.0-20240418144900-b7402ffdebc7
 	github.com/RomiChan/websocket v1.4.3-0.20220227141055-9b2c6168c9c5

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/FloatTech/sqlite v1.6.3 h1:MQkqBNlkPuCoKQQgoNLuTL/2Ci3tBTFAnVYBdD0Wy4
 github.com/FloatTech/sqlite v1.6.3/go.mod h1:zFbHzRfB+CJ+VidfjuVbrcin3DAz283F7hF1hIeHzpY=
 github.com/FloatTech/ttl v0.0.0-20230307105452-d6f7b2b647d1 h1:g4pTnDJUW4VbJ9NvoRfUvdjDrHz/6QhfN/LoIIpICbo=
 github.com/FloatTech/ttl v0.0.0-20230307105452-d6f7b2b647d1/go.mod h1:fHZFWGquNXuHttu9dUYoKuNbm3dzLETnIOnm1muSfDs=
-github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251025062608-50907f2e480b h1:SssPjgmi/2RlR6W5VLSPrec2+D4j8nGbGauEn+zQJFc=
-github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251025062608-50907f2e480b/go.mod h1:qwYPEv+WsrOeAKelGXbNerqY1FBZbOVK5RBRDi/jN4U=
+github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251030033604-587d2268813f h1:lRCs5MGWTEjxFvypEOguxKWDFN+VpYu5XQpWiTMMyDE=
+github.com/LagrangeDev/LagrangeGo v0.1.5-0.20251030033604-587d2268813f/go.mod h1:qwYPEv+WsrOeAKelGXbNerqY1FBZbOVK5RBRDi/jN4U=
 github.com/Microsoft/go-winio v0.6.2-0.20230724192519-b29bbd58a65a h1:aU1703IHxupjzipvhu16qYKLMR03e+8WuNR+JMsKfGU=
 github.com/Microsoft/go-winio v0.6.2-0.20230724192519-b29bbd58a65a/go.mod h1:OZqLNXdYJHmx7aqq/T6wAdFEdoGm5nmIfC4kU7M8P8o=
 github.com/RomiChan/protobuf v0.1.1-0.20230204044148-2ed269a2e54d h1:/Xuj3fIiMY2ls1TwvPKmaqQrtJsPY+c9s+0lOScVHd8=


### PR DESCRIPTION
1. Uin 在事件解析时已正常处理
2. 部分退群用户没缓存可能导致 member 为空 所以后续直接用 e.UserUin 防止报错